### PR TITLE
Add keep-alive step to pages workflow

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -15,6 +15,7 @@ permissions:
   contents: read
   pages: write
   id-token: write
+  actions: write
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
@@ -52,3 +53,23 @@ jobs:
 
       - id: deploy
         uses: actions/deploy-pages@v4
+
+      # GitHub disables scheduled workflows after 60 days without repo commits.
+      # Re-enable via API when approaching that window (no empty commits needed).
+      - name: Keep scheduled workflow alive
+        if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          repo="${{ github.repository }}"
+          default_branch=$(gh api "repos/${repo}" --jq '.default_branch')
+          last_commit_date=$(gh api "repos/${repo}/commits/${default_branch}" --jq '.commit.committer.date')
+          days_since=$(( ( $(date -u +%s) - $(date -u -d "$last_commit_date" +%s) ) / 86400 ))
+          echo "Days since last commit on ${default_branch}: ${days_since}"
+          if [ "$days_since" -lt 45 ]; then
+            echo "Repository is active; no keep-alive needed."
+            exit 0
+          fi
+          echo "Repository inactive for ${days_since} days; re-enabling scheduled workflow."
+          gh workflow enable pages.yml --repo "$repo"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a keep-alive step to the hourly Pages deploy workflow so GitHub does not auto-disable the scheduled cron after 60 days of repository inactivity.

## What changed

- Grant `actions: write` so the workflow can re-enable itself via the GitHub API.
- After each scheduled (or manually dispatched) run, check how many days have passed since the last commit on the default branch.
- If that gap is **45+ days**, call `gh workflow enable pages.yml` to reset GitHub's inactivity timer.

This uses the API instead of empty commits, so git history stays clean.

## Notes

- The step only runs on `schedule` and `workflow_dispatch` triggers. Push-triggered runs already count as repository activity.
- If the workflow was already disabled before this lands, it still needs a one-time manual enable (`Actions → Enable workflow` or `gh workflow enable pages.yml`).
- Once merged, the hourly cron should keep itself alive indefinitely as long as it remains enabled.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f4361-452a-7c5f-9a20-d112f0e44512"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f4361-452a-7c5f-9a20-d112f0e44512"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

